### PR TITLE
UICollectionViewController subclass should import UIKit header

### DIFF
--- a/AdvancedCollectionView/Framework/View Controllers/AAPLCollectionViewController.h
+++ b/AdvancedCollectionView/Framework/View Controllers/AAPLCollectionViewController.h
@@ -3,6 +3,8 @@
  See LICENSE.txt for this sample’s licensing information  
  */
 
+#import <UIKit/UIKit.h>
+
 @interface AAPLCollectionViewController : UICollectionViewController
 
 @end


### PR DESCRIPTION
Without this change subclasses of AAPLCollectionViewController will be required to include UIKit in their header, this also helps consistency since all other subclasses of UIKit classes include the UIKit in their headers.
